### PR TITLE
Pin WebkitGTK version in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,13 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libxdo-dev
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf libxdo-dev \
+            libwebkit2gtk-4.1-0=2.44.0-2 \
+            libwebkit2gtk-4.1-dev=2.44.0-2 \
+            libjavascriptcoregtk-4.1-0=2.44.0-2 \
+            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+            gir1.2-webkit2-4.1=2.44.0-2
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
We have to pin the version of this dependency because there appears to be some incompatibility problems on certain OS, where running the AppImage results in a EGL_BAD_PARAMETER. Reproducible on Fedora Workstation 42.

This fix comes from ZMK studio's fix for the same problem.

Fixes #3 